### PR TITLE
allow srcs in `py_console_script_binary` when using `py_test` as the binary

### DIFF
--- a/python/private/py_console_script_binary.bzl
+++ b/python/private/py_console_script_binary.bzl
@@ -17,6 +17,7 @@ Implementation for the macro to generate a console_script py_binary from an 'ent
 """
 
 load("//python:py_binary.bzl", "py_binary")
+load("//python:py_test.bzl", "py_test")
 load(":py_console_script_gen.bzl", "py_console_script_gen")
 
 def _dist_info(pkg):
@@ -72,8 +73,14 @@ def py_console_script_binary(
     """
     main = "rules_python_entry_point_{}.py".format(name)
 
-    if kwargs.pop("srcs", None):
+    srcs = kwargs.pop("srcs", [])
+
+    if binary_rule == py_test:
+        srcs = srcs + [main]
+    elif srcs:
         fail("passing 'srcs' attribute to py_console_script_binary is unsupported")
+    else:
+        srcs = [main]
 
     py_console_script_gen(
         name = "_{}_gen".format(name),
@@ -86,7 +93,7 @@ def py_console_script_binary(
 
     binary_rule(
         name = name,
-        srcs = [main],
+        srcs = srcs,
         main = main,
         deps = [pkg] + kwargs.pop("deps", []),
         **kwargs


### PR DESCRIPTION
This is mostly just a workaround for `rules_python < 1.3.0`. In https://github.com/bazel-contrib/rules_python/issues/2539, there was a new `python -m` invocation style via the `main_module` attribute. For instance, you can directly invoke **pytest** in `py_test` via:

```python
py_test(
    main_module = "pytest.main",
    ...
)
```

However, for `rules_python < 1.3.0`, we need something like this:

```python
load("@rules_python//python:py_test.bzl", "py_test")

py_console_script_binary(
    name = "test",
    args = args,
    pkg = "@pypi//pytest_bazel",
    script = "pytest_bazel",
    binary_rule = py_test,
)
```

However, when doing `bazel query 'kind("py_test", //target:test)' --output=build`, the `srcs` attribute of `py_test` would only be `["//target:rules_python_entry_point_test.py"]`.

This breaks some of the other rules/macros that read the `srcs` attribute of the `py_test` rule, as only the entry point is exposed, not the entire `srcs` of test files.